### PR TITLE
Fix Japanese ordinals

### DIFF
--- a/ja/ordinal.json
+++ b/ja/ordinal.json
@@ -1,6 +1,6 @@
 {
-  "default": "{{number}}位",
-  "1": "{{number}}位",
-  "2": "{{number}}位",
-  "3": "{{number}}位"
+  "default": "第{{number}}",
+  "1": "第{{number}}",
+  "2": "第{{number}}",
+  "3": "第{{number}}"
 }


### PR DESCRIPTION
1位, 2位, etc. is for contexts like position in a competition or race results, e.g. first place, second place.

For battalion names, the correct usage is 第1, 第2, etc. (e.g. see [JGSDF orbat](https://ja.wikipedia.org/wiki/陸上自衛隊#主要部隊) on wikipedia)

I also think there should not be a space after the number, so "第9戦列大隊" rather than "第9 戦列大隊" — but this is more open to preference. Let me know if you agree with this and I can bundle that change into this PR as well.